### PR TITLE
fix #52 (Info Table Bug When Using Percentage for Custom Dimensions)

### DIFF
--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -17,7 +17,7 @@ const Utils = (() => {
 
             dimension = this.TitleCase(dimension);
 
-            if (window && window.screen && Object.keys(window.screen).includes(`avail${dimension}`)) {
+            if (window && window.screen && window.screen[`avail${dimension}`] !== undefined) {
                 return parseInt(window.screen[`avail${dimension}`] * percentage, 10);
             }
 

--- a/src/pages/options/options.js
+++ b/src/pages/options/options.js
@@ -194,7 +194,9 @@ app.controller('OptionsController', ['$scope', '$timeout', 'kbdComboFilter', fun
                 width = Utils.GetDimensionForScreenPercentage('Width', width);
                 height = Utils.GetDimensionForScreenPercentage('Height', height);
             }
+        }
 
+        if ((parseInt(width, 10) > 0) && (parseInt(height, 10) > 0)) {
             ratio = gcd(width, height);
         }
 


### PR DESCRIPTION
* fix check for `window.screen.availWidth`/`window.screen.availHeight`
* ensure width and height are set before computing GCD