### PR TITLE
Fix: "Open Video in Popout Player" Context Menu

### DIFF
--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -35,7 +35,11 @@ export default defineBackground(() => {
   browser.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
     if (changeInfo.url && IsVideoURL(changeInfo.url, false)) {
       if (await Options.GetLocalOption("advanced", "autoOpen")) {
-        OpenPopoutBackgroundHelper(changeInfo.url, tabId, false);
+        OpenPopoutBackgroundHelper({
+          url: changeInfo.url,
+          tabId,
+          allowCloseTab: false,
+        });
       }
     }
   });

--- a/src/entrypoints/background/menus.ts
+++ b/src/entrypoints/background/menus.ts
@@ -62,15 +62,32 @@ const OnMenuClicked = async (
   switch (info.menuItemId) {
     case "OpenVideo":
     case "OpenPlaylist":
-      OpenPopoutBackgroundHelper(info.linkUrl, tab?.id, true, false);
+      OpenPopoutBackgroundHelper({
+        url: info.linkUrl,
+        tabId: tab?.id,
+        allowCloseTab: true,
+        allowCloseTabOnAnyDomain: false,
+      });
       break;
 
     case "OpenVideoRotateLeft":
-      OpenPopoutBackgroundHelper(info.linkUrl, tab?.id, true, false, 270);
+      OpenPopoutBackgroundHelper({
+        url: info.linkUrl,
+        tabId: tab?.id,
+        allowCloseTab: true,
+        allowCloseTabOnAnyDomain: false,
+        rotation: 270,
+      });
       break;
 
     case "OpenVideoRotateRight":
-      OpenPopoutBackgroundHelper(info.linkUrl, tab?.id, true, false, 90);
+      OpenPopoutBackgroundHelper({
+        url: info.linkUrl,
+        tabId: tab?.id,
+        allowCloseTab: true,
+        allowCloseTabOnAnyDomain: false,
+        rotation: 90,
+      });
       break;
   }
 };

--- a/src/entrypoints/background/menus.ts
+++ b/src/entrypoints/background/menus.ts
@@ -65,6 +65,7 @@ const OnMenuClicked = async (
       OpenPopoutBackgroundHelper({
         url: info.linkUrl,
         tabId: tab?.id,
+        includeList: info.menuItemId === "OpenPlaylist", // omit playlist when opening video only
         allowCloseTab: true,
         allowCloseTabOnAnyDomain: false,
       });

--- a/src/entrypoints/background/popout.ts
+++ b/src/entrypoints/background/popout.ts
@@ -34,18 +34,20 @@ const HEIGHT_PADDING = 40; // TODO: find a way to calculate this (or make it con
 export const OpenPopoutBackgroundHelper = async ({
   url,
   tabId = -1,
+  includeList = true,
   allowCloseTab = true,
   allowCloseTabOnAnyDomain = false,
   rotation = 0,
 }: {
   url: string;
+  includeList?: boolean;
   tabId?: number;
   allowCloseTab?: boolean;
   allowCloseTabOnAnyDomain?: boolean;
   rotation?: number;
 }): Promise<boolean> => {
   const id = GetVideoIDFromURL(url);
-  const list = GetPlaylistIDFromURL(url);
+  const list = includeList ? GetPlaylistIDFromURL(url) : undefined;
 
   if (!(id || list)) {
     console.warn("No video or playlist detected from URL", url);

--- a/src/entrypoints/background/popout.ts
+++ b/src/entrypoints/background/popout.ts
@@ -23,20 +23,27 @@ const HEIGHT_PADDING = 40; // TODO: find a way to calculate this (or make it con
 
 /**
  * Helper function to open the popout player from various points in the background script
- * @param {string} url the URL containing a video ID and/or playlist
- * @param {number} [tabId=-1] the ID of the original tab
- * @param {boolean} [allowCloseTab=true] if the original tab can be closed (depending on the user's preference)
- * @param {boolean} [allowCloseTabOnAnyDomain=false] if the original tab can be closed regardless of which domain it is on
- * @param {number} [rotation=0] the initial video rotation amount
+ * @param {object} params
+ * @param {string} params.url the URL containing a video ID and/or playlist
+ * @param {number} [params.tabId=-1] the ID of the original tab
+ * @param {boolean} [params.allowCloseTab=true] if the original tab can be closed (depending on the user's preference)
+ * @param {boolean} [params.allowCloseTabOnAnyDomain=false] if the original tab can be closed regardless of which domain it is on
+ * @param {number} [params.rotation=0] the initial video rotation amount
  * @returns {Promise<boolean>} if the popout player was opened
  */
-export const OpenPopoutBackgroundHelper = async (
-  url: string,
-  tabId: number = -1,
-  allowCloseTab: boolean = true,
-  allowCloseTabOnAnyDomain: boolean = false,
-  rotation: number = 0,
-): Promise<boolean> => {
+export const OpenPopoutBackgroundHelper = async ({
+  url,
+  tabId = -1,
+  allowCloseTab = true,
+  allowCloseTabOnAnyDomain = false,
+  rotation = 0,
+}: {
+  url: string;
+  tabId?: number;
+  allowCloseTab?: boolean;
+  allowCloseTabOnAnyDomain?: boolean;
+  rotation?: number;
+}): Promise<boolean> => {
   const id = GetVideoIDFromURL(url);
   const list = GetPlaylistIDFromURL(url);
 


### PR DESCRIPTION
This PR changes (corrects?) the behavior of the "Open Video in Popout Player" context menu to explicitly **not** include the list/playlist, resulting in **only** the target video being opened.

The "Open Playlist in Popout Player" context menu remains unchanged and will open the associated list/playlist as expected (when possible).