### PR TITLE
Fix for "Video Unavailable" (Error code 15)

### DIFF
--- a/src/entrypoints/background/popout.ts
+++ b/src/entrypoints/background/popout.ts
@@ -2,6 +2,7 @@ import type { Windows } from "wxt/browser";
 
 import {
   OPTION_DEFAULTS,
+  POPOUT_PLAYER_PARAM_NAME,
   START_THRESHOLD,
   YOUTUBE_EMBED_URL,
   YOUTUBE_NOCOOKIE_EMBED_URL,
@@ -112,7 +113,7 @@ export const OpenPopoutPlayer = async ({
   const params: Record<string, any> = {};
 
   // custom flag for determining if the embedded player is playing within a popout window/tab
-  params.popout = 1;
+  params[POPOUT_PLAYER_PARAM_NAME] = 1;
 
   const behavior = await Options.GetLocalOptionsForDomain("behavior");
 

--- a/src/entrypoints/background/tabs.ts
+++ b/src/entrypoints/background/tabs.ts
@@ -1,6 +1,7 @@
 import type { Tabs } from "wxt/browser";
 
 import {
+  POPOUT_PLAYER_PARAM_NAME,
   YOUTUBE_DOMAINS,
   YOUTUBE_EMBED_URL,
   YOUTUBE_NOCOOKIE_EMBED_URL,
@@ -95,7 +96,7 @@ export const GetPopoutPlayerTabs = async (
     await AddContextualIdentityToDataObject(
       {
         url: [YOUTUBE_EMBED_URL, YOUTUBE_NOCOOKIE_EMBED_URL].map(
-          (url) => url + "*?*popout=1*",
+          (url) => url + `*?*${POPOUT_PLAYER_PARAM_NAME}=1*`,
         ),
       },
       originTabId,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,5 @@
+export const POPOUT_PLAYER_PARAM_NAME = "__ytpp";
+
 export const YOUTUBE_DOMAIN = "youtube.com";
 export const YOUTUBE_NOCOOKIE_DOMAIN = "youtube-nocookie.com";
 export const YOUTUBE_DOMAINS = [YOUTUBE_DOMAIN, YOUTUBE_NOCOOKIE_DOMAIN];

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,4 +1,5 @@
 import {
+  POPOUT_PLAYER_PARAM_NAME,
   YOUTUBE_EMBED_URL,
   YOUTUBE_NOCOOKIE_EMBED_URL,
 } from "@/utils/constants";
@@ -65,7 +66,7 @@ export const IsPopoutPlayer = (location: Location): boolean => {
     location.href.startsWith(YOUTUBE_NOCOOKIE_EMBED_URL)
   ) {
     const params = new URLSearchParams(location.search.substring(1));
-    if (params.get("popout")) {
+    if (params.get(POPOUT_PLAYER_PARAM_NAME)) {
       return true;
     }
   }


### PR DESCRIPTION
This appears to be caused by the custom "popout" query parameter now being blacklisted by YouTube. For now the quick fix was to just rename that parameter.