### PR TITLE
update request headers in poput player; fixes #447 (for now)

### DIFF
--- a/src/public/rules.json
+++ b/src/public/rules.json
@@ -8,7 +8,12 @@
         {
           "header": "Referer",
           "operation": "set",
-          "value": "https://www.youtube.com/"
+          "value": "https://www.youtube-nocookie.com/"
+        },
+        {
+          "header": "Referrer-Policy",
+          "operation": "set",
+          "value": "strict-origin-when-cross-origin"
         }
       ]
     },
@@ -30,6 +35,11 @@
           "header": "Referer",
           "operation": "set",
           "value": "https://www.youtube-nocookie.com/"
+        },
+        {
+          "header": "Referrer-Policy",
+          "operation": "set",
+          "value": "strict-origin-when-cross-origin"
         }
       ]
     },


### PR DESCRIPTION
- enforce "strict-origin-when-cross-origin" value for "Referrer-Policy"
- always use "youtube-nocookie.com" as the Referer