### PR TITLE
Add Firefox data collection permissions

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -89,6 +89,9 @@ export default defineConfig({
         gecko: {
           id: "{85b42b8f-49cd-4935-aeca-a6b32dd6ac9f}",
           strict_min_version: "113.0",
+          data_collection_permissions: {
+            required: ["none"],
+          },
         },
       };
     }


### PR DESCRIPTION
## Summary
- Add Firefox `browser_specific_settings.gecko.data_collection_permissions.required` with `["none"]`.
- Satisfy the Firefox/WXT warning for explicit data collection permissions.

## Validation
- `npm run compile`
- `npm run lint`
- `npm run build:firefox`
- `npx web-ext lint --source-dir=.output/firefox-mv3/`

## Notes
- `web-ext lint` passes with 0 errors and 2 generated bundle warnings for unsafe `innerHTML` assignment in `chunks/options-CuldZvaX.js`.
- `npm ci` reported existing dependency audit and deprecation warnings while installing missing local dependencies.
