### PR TITLE
[codex] update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/nextrelease.yml
+++ b/.github/workflows/nextrelease.yml
@@ -11,12 +11,13 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' && github.head_ref == 'nextrelease' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v5
       with:
         node-version: 'lts/*'
+        package-manager-cache: false
     - uses: dropseed/nextrelease@v1
       with:
         prepare_cmd: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
       with:
         node-version: "lts/*"
         cache: npm


### PR DESCRIPTION
## Summary

Updates the repository-owned GitHub Actions workflow dependencies that were still backed by older JavaScript action runtimes.

- Updates `actions/checkout` to `v5` in the test and nextrelease workflows.
- Updates `actions/setup-node` to `v5` in the test and nextrelease workflows.
- Disables `setup-node@v5` automatic package-manager caching in the nextrelease workflow, where caching is not needed.

## Third-party action check

`dropseed/changerelease@v1` is a composite action and does not declare a Node 20 JavaScript runtime. `dropseed/nextrelease@v1` is also composite. A newer `dropseed/nextrelease@v2` exists, but its action manifest invokes older `actions/checkout@v3` and `actions/setup-python@v3`, so this PR keeps `dropseed/nextrelease@v1` as the safer change for the Node 20 deprecation notice.

## Validation

- `%TEMP%\actionlint-bin\actionlint.exe .github/workflows/test.yml .github/workflows/nextrelease.yml`
- `%TEMP%\actionlint-bin\actionlint.exe` against all resolved `.github/workflows/*.yml` files
- `npx prettier --parser yaml` on `.github/workflows/*.yml`
- `rg` check for old direct `actions/checkout` / `actions/setup-node` pins and insecure Node 20 opt-out env vars
- `npm run compile`
- `npm run lint`
- `npm run test:unit`