### PR TITLE
Focus reused popout tabs

### DIFF
--- a/src/entrypoints/background/popout.ts
+++ b/src/entrypoints/background/popout.ts
@@ -17,6 +17,7 @@ import {
   CloseTab,
   GetActiveTab,
   GetPopoutPlayerTabs,
+  UpdatePopoutPlayerTab,
 } from "./tabs";
 
 const WIDTH_PADDING = 16; // TODO: find a way to calculate this (or make it configurable)
@@ -205,21 +206,20 @@ export const OpenPopoutPlayer = async ({
     "behavior",
     "reuseWindowsTabs",
   );
+  const openInBackground = await Options.GetLocalOption(
+    "advanced",
+    "background",
+  );
 
   if (reuseExistingWindowsTabs) {
     const tabs = await GetPopoutPlayerTabs(originTabId);
     if (tabs.length > 0) {
       result = await Promise.all(
-        tabs.map((tab) => browser.tabs.update(tab.id, { url })),
+        tabs.map((tab) => UpdatePopoutPlayerTab(tab, url, !openInBackground)),
       );
       return result;
     }
   }
-
-  const openInBackground = await Options.GetLocalOption(
-    "advanced",
-    "background",
-  );
 
   switch (behavior.target.toLowerCase()) {
     case "tab":
@@ -299,8 +299,9 @@ export const OpenPopoutPlayerInWindow = async (
   const isFirefox = await IsFirefox();
 
   if (isFirefox) {
-    (createData as Browser.windows.CreateData & { titlePreface?: string }).titlePreface =
-      await Options.GetLocalOption("advanced", "title");
+    (
+      createData as Browser.windows.CreateData & { titlePreface?: string }
+    ).titlePreface = await Options.GetLocalOption("advanced", "title");
   }
 
   const createdWindow = await browser.windows.create(createData);

--- a/src/entrypoints/background/tabs.ts
+++ b/src/entrypoints/background/tabs.ts
@@ -104,6 +104,32 @@ export const GetPopoutPlayerTabs = async (
   );
 
 /**
+ * Updates an existing popout player tab with the given URL.
+ * @param {Browser.tabs.Tab} tab the existing popout player tab
+ * @param {string} url the updated popout player URL
+ * @param {boolean} [active] indicates if the tab should become active
+ * @returns {Promise<Browser.tabs.Tab | undefined>}
+ */
+export const UpdatePopoutPlayerTab = async (
+  tab: Browser.tabs.Tab,
+  url: string,
+  active: boolean = true,
+): Promise<Browser.tabs.Tab | undefined> => {
+  const updatedTab = await browser.tabs.update(tab.id, {
+    ...(active ? { active: true } : {}),
+    url,
+  });
+
+  if (active && tab.windowId !== undefined) {
+    await browser.windows.update(tab.windowId, {
+      focused: true,
+    });
+  }
+
+  return updatedTab;
+};
+
+/**
  * Gets the value of the `cookieStoreId` property of the specified tab
  * @param {number} tabId the ID of the tab
  * @returns {Promise<string | undefined>} the `cookieStoreId` property value or `undefined` if unavailable

--- a/tests/unit/tabs.test.ts
+++ b/tests/unit/tabs.test.ts
@@ -1,0 +1,74 @@
+import type { Browser } from "wxt/browser";
+import { UpdatePopoutPlayerTab } from "@/entrypoints/background/tabs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const createTab = (): Browser.tabs.Tab => ({
+  active: false,
+  autoDiscardable: true,
+  discarded: false,
+  frozen: false,
+  groupId: -1,
+  highlighted: false,
+  id: 123,
+  incognito: false,
+  index: 0,
+  pinned: false,
+  selected: false,
+  windowId: 456,
+});
+
+describe("UpdatePopoutPlayerTab", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(globalThis, "browser");
+  });
+
+  it("activates the reused tab and focuses its window when active", async () => {
+    const updateTab = vi.fn().mockResolvedValue({ id: 123 });
+    const updateWindow = vi.fn().mockResolvedValue({ id: 456 });
+    vi.stubGlobal("browser", {
+      tabs: {
+        update: updateTab,
+      },
+      windows: {
+        update: updateWindow,
+      },
+    });
+
+    await UpdatePopoutPlayerTab(
+      createTab(),
+      "https://www.youtube.com/embed/dQw4w9WgXcQ?popout=1",
+      true,
+    );
+
+    expect(updateTab).toHaveBeenCalledWith(123, {
+      active: true,
+      url: "https://www.youtube.com/embed/dQw4w9WgXcQ?popout=1",
+    });
+    expect(updateWindow).toHaveBeenCalledWith(456, { focused: true });
+  });
+
+  it("updates the reused tab in the background without changing focus", async () => {
+    const updateTab = vi.fn().mockResolvedValue({ id: 123 });
+    const updateWindow = vi.fn().mockResolvedValue({ id: 456 });
+    vi.stubGlobal("browser", {
+      tabs: {
+        update: updateTab,
+      },
+      windows: {
+        update: updateWindow,
+      },
+    });
+
+    await UpdatePopoutPlayerTab(
+      createTab(),
+      "https://www.youtube.com/embed/dQw4w9WgXcQ?popout=1",
+      false,
+    );
+
+    expect(updateTab).toHaveBeenCalledWith(123, {
+      url: "https://www.youtube.com/embed/dQw4w9WgXcQ?popout=1",
+    });
+    expect(updateWindow).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
﻿## Summary

- Route reused popout tab updates through a focused helper instead of updating only the URL.
- When foreground behavior is requested, update the reused tab with `active: true` and focus its containing window.
- Keep background reuse as a URL-only tab update.
- Add unit coverage for foreground and background reused-tab behavior.

## Root Cause

The reused-tab path returned before applying the `Open in Background Tab` preference. Existing popout tabs were updated with only `{ url }`, so the browser had no request to activate the tab or focus the containing window.

MDN and Chrome extension docs indicate `tabs.update({ active: true })` activates a tab but does not focus its window; `windows.update({ focused: true })` is the corresponding window-focus API.

Fixes #452.

## Validation

- `npm run compile`
- `npm run lint`
- `npm run test:unit`
- `npm run build:firefox`
- `npm run build:chrome`
- `npm run build:edge`
- `npx web-ext lint --source-dir=./.output/firefox-mv3/` (0 errors; existing options-bundle `innerHTML` warnings remain)
