### PR TITLE
Handle private window popout limitations

### DIFF
--- a/docs/pages/faq.html
+++ b/docs/pages/faq.html
@@ -36,6 +36,19 @@ order: 4
 
 <div class="divider"></div>
 
+<section id="private-incognito" class="section scrollspy">
+    <h4 class="hide">Private and Incognito Windows</h4>
+    <h5><i class="material-icons">question_answer</i> Does the popout player work in Private or Incognito windows?</h5>
+
+    <p>Usually, but browser support has some important limits. Browsers only expose Private or Incognito tabs to extensions after the extension is allowed to run in private browsing. Firefox and Chromium also handle private extension contexts differently: Firefox uses the default <a class="red-text" href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/incognito" rel="nofollow">spanning private browsing model</a>, while Chrome recommends <a class="red-text" href="https://developer.chrome.com/docs/extensions/reference/manifest/incognito" rel="nofollow">split incognito behavior</a> for extensions that need to load tabs in an Incognito browser.</p>
+
+    <p>In Firefox, Multi-Account Containers support depends on the browser's <a class="red-text" href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities" rel="nofollow">contextual identities</a> and <a class="red-text" href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create" rel="nofollow">cookie store</a> APIs. Firefox also lets extensions request whether a new popup window should be private through <a class="red-text" href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/create" rel="nofollow"><code>windows.create()</code></a>. YouTube Popout Player now passes both the original tab's Private Window state and, when enabled, its cookie store to Firefox when opening a popup window.</p>
+
+    <p>If Firefox still opens the popout player outside the Private window or fails to open it when Multi-Account Containers support is enabled, configure YouTube Popout Player to open in a tab instead of a popup window, or disable Multi-Account Containers support for popup-window use. The extension will show a notification when the browser reports an opening failure or when a private popup window is not preserved.</p>
+</section>
+
+<div class="divider"></div>
+
 <section id="multi-monitor" class="section scrollspy">
     <h4 class="hide">Second Monitor/Screen</h4>
     <h5><i class="material-icons">question_answer</i> Can I open the popout player on a second display/monitor/screen? <span class="badge red white-text">New!</span></h5>

--- a/src/entrypoints/background/popout.ts
+++ b/src/entrypoints/background/popout.ts
@@ -16,11 +16,30 @@ import {
   AddContextualIdentityToDataObject,
   CloseTab,
   GetActiveTab,
+  GetOriginTabContext,
   GetPopoutPlayerTabs,
 } from "./tabs";
 
 const WIDTH_PADDING = 16; // TODO: find a way to calculate this (or make it configurable)
 const HEIGHT_PADDING = 40; // TODO: find a way to calculate this (or make it configurable)
+
+const ShowPopoutOpenFailureNotification = async (error?: unknown) => {
+  if (error !== undefined) {
+    console.error("[Background] Failed to open popout player", error);
+  }
+
+  const message =
+    browser.i18n.getMessage("Notification_Error_PopoutOpenFailed") ||
+    "The popout player could not be opened.";
+  ShowBasicNotification({ message });
+};
+
+const ShowPrivateWindowNotPreservedNotification = async () => {
+  const message =
+    browser.i18n.getMessage("Notification_Warning_PrivateWindowNotPreserved") ||
+    "The popout player was opened outside the original private window.";
+  ShowBasicNotification({ message });
+};
 
 /**
  * Helper function to open the popout player from various points in the background script
@@ -61,6 +80,11 @@ export const OpenPopoutBackgroundHelper = async ({
     rotation,
     originTabId: tabId,
   });
+  const opened = result !== undefined && result !== null;
+
+  if (!opened) {
+    return false;
+  }
 
   // we can't do anything if a tab ID wasn't given, as the "active" tab will now likely be the popout
   // (unless the user has configured it to open in the background, but checking for that is not guaranteed)
@@ -76,7 +100,7 @@ export const OpenPopoutBackgroundHelper = async ({
     }
   }
 
-  return result !== undefined && result !== null;
+  return true;
 };
 
 /**
@@ -252,17 +276,23 @@ export const OpenPopoutPlayerInTab = async (
   url: string,
   active: boolean = true,
   originTabId: number = -1,
-): Promise<object> => {
+): Promise<object | null> => {
   const createData = await AddContextualIdentityToDataObject(
     {
       url,
       active,
-    },
+    } as Browser.tabs.CreateProperties,
     originTabId,
+    { includeWindowId: true },
   );
 
-  const tab = await browser.tabs.create(createData);
-  return tab;
+  try {
+    const tab = await browser.tabs.create(createData);
+    return tab;
+  } catch (error) {
+    await ShowPopoutOpenFailureNotification(error);
+    return null;
+  }
 };
 
 /**
@@ -280,11 +310,12 @@ export const OpenPopoutPlayerInWindow = async (
   originTabId: number = -1,
   originalVideoWidth: number = OPTION_DEFAULTS.size.width,
   originalVideoHeight: number = OPTION_DEFAULTS.size.height,
-): Promise<object> => {
+): Promise<object | null> => {
   const dimensions = await GetDimensionsForPopoutPlayerWindow(
     originalVideoWidth,
     originalVideoHeight,
   );
+  const originContext = await GetOriginTabContext(originTabId);
 
   const createData = await AddContextualIdentityToDataObject(
     {
@@ -294,22 +325,41 @@ export const OpenPopoutPlayerInWindow = async (
       ...dimensions,
     } as Browser.windows.CreateData,
     originTabId,
+    { includeIncognito: true },
   );
 
   const isFirefox = await IsFirefox();
 
   if (isFirefox) {
-    (createData as Browser.windows.CreateData & { titlePreface?: string }).titlePreface =
-      await Options.GetLocalOption("advanced", "title");
+    (
+      createData as Browser.windows.CreateData & { titlePreface?: string }
+    ).titlePreface = await Options.GetLocalOption("advanced", "title");
   }
 
-  const createdWindow = await browser.windows.create(createData);
+  let createdWindow;
+  try {
+    createdWindow = await browser.windows.create(createData);
+  } catch (error) {
+    await ShowPopoutOpenFailureNotification(error);
+    return null;
+  }
 
   if (createdWindow === undefined) {
     console.warn(
       "[Background] OpenPopoutPlayerInWindow() :: windows.create() returned no window",
     );
-    return {};
+    await ShowPopoutOpenFailureNotification();
+    return null;
+  }
+
+  if (
+    originContext.incognito === true &&
+    (createdWindow as Browser.windows.Window).incognito !== true
+  ) {
+    console.warn(
+      "[Background] OpenPopoutPlayerInWindow() :: Created window did not preserve private browsing context",
+    );
+    await ShowPrivateWindowNotPreservedNotification();
   }
 
   if (createdWindow.id === undefined) {

--- a/src/entrypoints/background/tabs.ts
+++ b/src/entrypoints/background/tabs.ts
@@ -9,6 +9,24 @@ import {
 import { IsFirefox } from "@/utils/misc";
 import Options from "@/utils/options";
 
+export type OriginTabContext = {
+  cookieStoreId?: string;
+  incognito?: boolean;
+  windowId?: number;
+};
+
+export type TabContextOptions = {
+  includeCookieStoreId?: boolean;
+  includeIncognito?: boolean;
+  includeWindowId?: boolean;
+};
+
+type ContextDataObject = {
+  cookieStoreId?: string;
+  incognito?: boolean;
+  windowId?: number;
+};
+
 /**
  * Closes the specified tab
  * @param {number} tabId the ID of the tab to close
@@ -128,36 +146,96 @@ export const GetCookieStoreIDForTab = async (
 };
 
 /**
+ * Gets the relevant window/privacy/container context for the specified tab.
+ * @param {number} tabId the ID of the tab
+ * @returns tab context values, or an empty object if unavailable
+ */
+export const GetOriginTabContext = async (
+  tabId: number,
+): Promise<OriginTabContext> => {
+  if (isNaN(tabId) || +tabId <= 0) {
+    return {};
+  }
+
+  let tab: Browser.tabs.Tab;
+  try {
+    tab = await browser.tabs.get(tabId);
+  } catch (error) {
+    console.warn(
+      "[Background] GetOriginTabContext() :: Failed to get original tab",
+      error,
+    );
+    return {};
+  }
+
+  const context: OriginTabContext = {
+    incognito: tab.incognito,
+    windowId: tab.windowId,
+  };
+
+  if (Object.prototype.hasOwnProperty.call(tab, "cookieStoreId")) {
+    context.cookieStoreId = (
+      tab as Browser.tabs.Tab & { cookieStoreId?: string }
+    ).cookieStoreId;
+  }
+
+  return context;
+};
+
+/**
+ * Adds selected context values from an origin tab to browser tab/window creation data.
+ */
+export const ApplyOriginTabContextToDataObject = <T extends object>(
+  data: T,
+  context: OriginTabContext,
+  options: TabContextOptions = {},
+): T & ContextDataObject => {
+  const dataWithContext = data as T & ContextDataObject;
+
+  if (options.includeCookieStoreId && context.cookieStoreId) {
+    dataWithContext.cookieStoreId = context.cookieStoreId;
+  }
+
+  if (options.includeIncognito && typeof context.incognito === "boolean") {
+    dataWithContext.incognito = context.incognito;
+  }
+
+  if (options.includeWindowId && typeof context.windowId === "number") {
+    dataWithContext.windowId = context.windowId;
+  }
+
+  return dataWithContext;
+};
+
+/**
  * Adds the contextual identify properties to the given window/tab data object (if appropriate)
  * @param data an object for use in a window/tab function
  * @param {number} originTabId the original tab ID (of which to match the contextual identify)
  * @returns modified window/tab data object
  */
-export const AddContextualIdentityToDataObject = async <
-  T extends (Browser.tabs.QueryInfo | Browser.tabs.CreateProperties) & {
-    cookieStoreId?: string;
-  },
->(
+export const AddContextualIdentityToDataObject = async <T extends object>(
   data: T,
   originTabId: number = -1,
-): Promise<T> => {
+  options: Omit<TabContextOptions, "includeCookieStoreId"> = {},
+): Promise<T & ContextDataObject> => {
   try {
     const isFirefox = await IsFirefox();
     const useContextualIdentity = await Options.GetLocalOption(
       "advanced",
       "contextualIdentity",
     );
+    const context = await GetOriginTabContext(originTabId);
 
-    if (isFirefox && useContextualIdentity) {
-      const cookieStoreId = await GetCookieStoreIDForTab(originTabId);
-      if (cookieStoreId) {
-        data.cookieStoreId = cookieStoreId;
-      } else {
-        console.warn(
-          "[Background] AddContextualIdentityToObjectData() :: Failed to get cookie store ID from original tab",
-        );
-      }
+    if (isFirefox && useContextualIdentity && !context.cookieStoreId) {
+      console.warn(
+        "[Background] AddContextualIdentityToObjectData() :: Failed to get cookie store ID from original tab",
+      );
     }
+
+    return ApplyOriginTabContextToDataObject(data, context, {
+      ...options,
+      includeCookieStoreId: isFirefox && useContextualIdentity,
+    });
   } catch (error) {
     console.error(
       "Failed to add contextual identity to window/tab data object",
@@ -165,5 +243,5 @@ export const AddContextualIdentityToDataObject = async <
     );
   }
 
-  return data;
+  return data as T & ContextDataObject;
 };

--- a/src/public/_locales/en/messages.json
+++ b/src/public/_locales/en/messages.json
@@ -63,6 +63,14 @@
     "message": "Failed to determine the video and/or playlist to open. The popout player will not be opened.",
     "description": "The text used for the notification that is displayed when the popout player cannot be opened."
   },
+  "Notification_Error_PopoutOpenFailed": {
+    "message": "The popout player could not be opened. If this happened in a Firefox Private window, try opening in a tab or disabling Multi-Account Containers support.",
+    "description": "The text used for the notification that is displayed when the browser fails to open the popout player."
+  },
+  "Notification_Warning_PrivateWindowNotPreserved": {
+    "message": "Firefox opened the popout player outside the original Private window. Try opening in a tab, or disable Multi-Account Containers support for popup windows.",
+    "description": "The text used for the notification that is displayed when Firefox does not preserve the private window context."
+  },
   "PopoutPlayerControls_RotateVideo_Left": {
     "message": "Rotate video left by 90 degrees",
     "description": "The title for the player controls button that rotates the video in the popout player to the left by 90 degrees."

--- a/tests/unit/tabs.test.ts
+++ b/tests/unit/tabs.test.ts
@@ -1,0 +1,46 @@
+import { ApplyOriginTabContextToDataObject } from "@/entrypoints/background/tabs";
+import { describe, expect, it } from "vitest";
+
+describe("ApplyOriginTabContextToDataObject", () => {
+  it("adds selected private window and cookie store context", () => {
+    const data = ApplyOriginTabContextToDataObject(
+      { url: "https://www.youtube.com/embed/dQw4w9WgXcQ" },
+      {
+        cookieStoreId: "firefox-private",
+        incognito: true,
+        windowId: 123,
+      },
+      {
+        includeCookieStoreId: true,
+        includeIncognito: true,
+        includeWindowId: true,
+      },
+    );
+
+    expect(data).toEqual({
+      url: "https://www.youtube.com/embed/dQw4w9WgXcQ",
+      cookieStoreId: "firefox-private",
+      incognito: true,
+      windowId: 123,
+    });
+  });
+
+  it("only adds explicitly requested context values", () => {
+    const data = ApplyOriginTabContextToDataObject(
+      { url: "https://www.youtube.com/embed/dQw4w9WgXcQ" },
+      {
+        cookieStoreId: "firefox-container-1",
+        incognito: false,
+        windowId: 456,
+      },
+      {
+        includeCookieStoreId: true,
+      },
+    );
+
+    expect(data).toEqual({
+      url: "https://www.youtube.com/embed/dQw4w9WgXcQ",
+      cookieStoreId: "firefox-container-1",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Preserve the origin tab's private/window context when opening popout tabs and Firefox popup windows.
- Add user notifications when browser tab/window creation fails or Firefox returns a non-private popup for a private origin tab.
- Add FAQ documentation for Firefox Private Window, Multi-Account Containers, and Chromium Incognito behavior with primary documentation links.
- Add a focused unit test for applying origin tab context to browser create data.

## Research notes

Primary references used:

- MDN `windows.create()`: supports `incognito` and `cookieStoreId` in window creation data, and rejects on errors.
- MDN `tabs.create()`: supports `cookieStoreId` with the `cookies` permission and `windowId` to target a window.
- MDN contextual identities guide: Firefox containers use `cookieStoreId`, and using it with `tabs.create()` requires `cookies` permission.
- MDN manifest `incognito`: Firefox defaults to spanning private browsing behavior and does not support split mode.
- Chrome manifest `incognito`: Chrome recommends split mode for extensions that need to load tabs in an Incognito browser.
- Chrome `windows` API: background/service worker current window can differ from the focused/topmost browser window.

## Validation

- `npm run compile`
- `npm run test:unit`
- `npm run lint`
- `npx prettier --check src/entrypoints/background/popout.ts src/entrypoints/background/tabs.ts src/public/_locales/en/messages.json tests/unit/tabs.test.ts`
- `npm run build:firefox; if ($LASTEXITCODE -eq 0) { npx web-ext lint --source-dir=./.output/firefox-mv3/ }`

Notes: `npm run test:firefox` currently fails before validation because the script expands to `run-s build:* firefox` and `firefox` is not a task. The direct intended Firefox build/lint commands pass with 0 errors and 2 existing generated options-bundle `innerHTML` warnings.

## Remaining risk

This preserves the context that extension APIs expose, but Firefox Private Window + popup + container behavior is still browser-runtime behavior that should be manually checked in Firefox with private browsing access enabled.