### PR TITLE
[codex] coordinate release workflows

### DIFF
--- a/.github/workflows/changerelease.yml
+++ b/.github/workflows/changerelease.yml
@@ -6,8 +6,15 @@ on:
     branches: [master]
     tags: ["*"]
 
+permissions:
+  contents: write
+
 jobs:
   sync:
+    # nextrelease creates the semver tag after the release commit lands. Let
+    # nextrelease run changerelease after that point so this branch-triggered
+    # workflow does not fail while the tag is still missing.
+    if: ${{ github.event_name != 'push' || github.ref_type == 'tag' || !startsWith(github.event.head_commit.message, 'Release version ') }}
     runs-on: ubuntu-latest
     steps:
     - uses: dropseed/changerelease@v1

--- a/.github/workflows/nextrelease.yml
+++ b/.github/workflows/nextrelease.yml
@@ -6,9 +6,14 @@ on:
     branches: [master]
     types: [labeled, unlabeled, edited, synchronize]
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   sync:
-    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' && github.head_ref == 'nextrelease' }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.head_ref == 'nextrelease') }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
@@ -28,3 +33,10 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         tag_prefix: v
         next_branch: nextrelease
+    - name: Sync GitHub release from changelog
+      if: ${{ github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Release version ') }}
+      uses: dropseed/changerelease@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        tag_prefix: v
+        changelog: CHANGELOG.md


### PR DESCRIPTION
## Summary
- coordinate nextrelease and changerelease so release-merge pushes do not run changerelease before nextrelease creates the semver tag
- run changerelease as a follow-up step inside nextrelease after a `Release version ...` push has created the tag and GitHub Release
- declare the GITHUB_TOKEN permissions the release actions need for contents, labels, and pull requests

## Root Cause
`changerelease` fails when `CHANGELOG.md` includes a version whose `vX.Y.Z` tag is not present yet. On a nextrelease merge, the branch push can trigger both workflows at once: changerelease sees the new changelog immediately, while nextrelease has not yet created the tag/release. The later tag push is made with `GITHUB_TOKEN`, which does not trigger another push workflow run, so the failed changerelease run is not automatically retried.

## Validation
- `npx prettier --check .github/workflows/changerelease.yml .github/workflows/nextrelease.yml`
- `actionlint .github/workflows/changerelease.yml .github/workflows/nextrelease.yml`
- `git diff --check`
- `rg` check for old official action versions / fixed Node fallbacks in `.github/workflows`
- `npm run compile`