### PR TITLE
Fix malformed options documentation tag

### DIFF
--- a/docs/pages/options.html
+++ b/docs/pages/options.html
@@ -22,7 +22,7 @@ order: 5
 
         <div class="card-body">
             <dl>
-                <dt>Open in a Popup Window</d>
+                <dt>Open in a Popup Window</dt>
                 <dd>
                     <p>The popout player will open in a new popup window. <strong>This is the default setting.</strong></p>
                 </dd>


### PR DESCRIPTION
## Summary
- Fix the malformed closing tag for the first options documentation term in docs/pages/options.html.

## Validation
- git diff --check
- node tag-count sanity check for docs/pages/options.html: openDt=22, closeDt=22, badCloseD=0
- npm run docs:build could not run locally because Ruby Bundler (bundle) is not installed on this machine.