### PR TITLE
Fix options layout props for MUI 9

### DIFF
--- a/src/entrypoints/options/OptionsApp.tsx
+++ b/src/entrypoints/options/OptionsApp.tsx
@@ -120,7 +120,7 @@ export default function OptionsApp() {
               ))}
             </TabContext>
           </Paper>
-          <Box marginTop={1} marginBottom={2} marginX={1}>
+          <Box sx={{ mt: 1, mb: 2, mx: 1 }}>
             <Alert
               severity="info"
               icon={<CloudOffIcon color="primary" fontSize="inherit" />}
@@ -133,14 +133,13 @@ export default function OptionsApp() {
               />
             </Alert>
           </Box>
-          <Box marginTop={2} marginBottom={1}>
+          <Box sx={{ mt: 2, mb: 1 }}>
             <Stack
               direction={{
                 xs: "column",
                 sm: "row",
               }}
-              justifyContent="space-between"
-              alignItems="center"
+              sx={{ justifyContent: "space-between", alignItems: "center" }}
             >
               <ResetOptions />
               <FormControlLabel

--- a/src/entrypoints/options/components/ResetOptions.tsx
+++ b/src/entrypoints/options/components/ResetOptions.tsx
@@ -41,7 +41,7 @@ export default function ResetOptions() {
 
   return (
     <>
-      <Box mx={2}>
+      <Box sx={{ mx: 2 }}>
         <Button
           variant="contained"
           color="secondary"

--- a/src/entrypoints/options/components/TabPanelHeader.tsx
+++ b/src/entrypoints/options/components/TabPanelHeader.tsx
@@ -15,8 +15,7 @@ export default function TabPanelHeader({
       wrap="nowrap"
       spacing={1}
       direction="row"
-      justifyContent="flex-start"
-      alignItems="center"
+      sx={{ justifyContent: "flex-start", alignItems: "center" }}
     >
       {icon && <Grid>{icon}</Grid>}
       <Grid size="grow">

--- a/src/entrypoints/options/components/forms/CustomDimensionsForm.tsx
+++ b/src/entrypoints/options/components/forms/CustomDimensionsForm.tsx
@@ -214,7 +214,7 @@ function CustomDimensionsForm() {
     height !== options["height"];
 
   return (
-    <Box padding={2}>
+    <Box sx={{ p: 2 }}>
       <FormControl fullWidth>
         <InputLabel id="size-units-label">
           {browser.i18n.getMessage("DimensionUnitsLabel")}
@@ -237,8 +237,7 @@ function CustomDimensionsForm() {
         container
         spacing={2}
         direction="row"
-        justifyContent="flex-start"
-        alignItems="center"
+        sx={{ justifyContent: "flex-start", alignItems: "center" }}
       >
         <Grid size="grow">
           <TextField
@@ -295,14 +294,14 @@ function CustomDimensionsForm() {
           />
         </Grid>
       </Grid>
-      <Box padding={2}>
+      <Box sx={{ p: 2 }}>
         <CustomDimensionsInfoTable
           units={units}
           width={width}
           height={height}
         />
       </Box>
-      <Box paddingX={8}>
+      <Box sx={{ px: 8 }}>
         <Button
           variant="contained"
           color="primary"

--- a/src/entrypoints/options/components/forms/CustomPositionForm.tsx
+++ b/src/entrypoints/options/components/forms/CustomPositionForm.tsx
@@ -51,7 +51,7 @@ function CustomPositionForm() {
     top !== options["top"] || left !== options["left"];
 
   return (
-    <Box padding={2}>
+    <Box sx={{ p: 2 }}>
       <Alert
         severity="info"
         icon={<WarningIcon color="secondary" fontSize="inherit" />}
@@ -66,8 +66,7 @@ function CustomPositionForm() {
         container
         spacing={2}
         direction="row"
-        justifyContent="flex-start"
-        alignItems="center"
+        sx={{ justifyContent: "flex-start", alignItems: "center" }}
       >
         <Grid size="grow">
           <TextField
@@ -116,7 +115,7 @@ function CustomPositionForm() {
           />
         </Grid>
       </Grid>
-      <Box paddingX={8}>
+      <Box sx={{ px: 8 }}>
         <Button
           variant="contained"
           color="primary"

--- a/src/entrypoints/options/components/tabs/AdvancedTab.tsx
+++ b/src/entrypoints/options/components/tabs/AdvancedTab.tsx
@@ -213,31 +213,31 @@ export default function AdvancedTab() {
         icon={<SettingsIcon />}
         title={browser.i18n.getMessage("OptionsHeadingAdvanced")}
       />
-      <Box marginTop={1} marginBottom={2}>
+      <Box sx={{ mt: 1, mb: 2 }}>
         <CloseOptionControl />
       </Box>
       <Divider />
-      <Box marginY={2}>
+      <Box sx={{ my: 2 }}>
         <BackgroundTabControl />
       </Box>
       <Divider />
-      <Box marginY={2}>
+      <Box sx={{ my: 2 }}>
         <YouTubeNoCookieDomainControl />
       </Box>
       {isFirefox && (
         <>
           <Divider />
-          <Box marginY={2}>
+          <Box sx={{ my: 2 }}>
             <TitleOptionControl />
           </Box>
           <Divider />
-          <Box marginY={2}>
+          <Box sx={{ my: 2 }}>
             <ContextualIdentitySupportControl />
           </Box>
         </>
       )}
       <Divider />
-      <Box marginY={2}>
+      <Box sx={{ my: 2 }}>
         <AutoOpenControl />
       </Box>
     </Box>

--- a/src/entrypoints/options/components/tabs/BehaviorTab.tsx
+++ b/src/entrypoints/options/components/tabs/BehaviorTab.tsx
@@ -105,7 +105,7 @@ export default function BehaviorTab() {
             "OptionsBehaviorAutoplayDescription",
           )}
         />
-        <Box mt={1}>
+        <Box sx={{ mt: 1 }}>
           <Alert severity="warning" icon={false}>
             <Typography
               dangerouslySetInnerHTML={{
@@ -197,31 +197,31 @@ export default function BehaviorTab() {
         icon={<TuneIcon />}
         title={browser.i18n.getMessage("OptionsHeadingBehavior")}
       />
-      <Box marginTop={1} marginBottom={2}>
+      <Box sx={{ mt: 1, mb: 2 }}>
         <TargetOptionControl />
       </Box>
       <Divider />
-      <Box marginY={2}>
+      <Box sx={{ my: 2 }}>
         <ReuseExistingOptionControl />
       </Box>
       <Divider />
-      <Box marginY={2}>
+      <Box sx={{ my: 2 }}>
         <ShowControlsOptionControl />
       </Box>
       <Divider />
-      <Box marginY={2}>
+      <Box sx={{ my: 2 }}>
         <AutoplayControl />
       </Box>
       <Divider />
-      <Box marginY={2}>
+      <Box sx={{ my: 2 }}>
         <ResumePlaybackControl />
       </Box>
       <Divider />
-      <Box marginY={2}>
+      <Box sx={{ my: 2 }}>
         <LoopControl />
       </Box>
       <Divider />
-      <Box marginY={2}>
+      <Box sx={{ my: 2 }}>
         <RotationControls />
       </Box>
     </Box>

--- a/src/entrypoints/options/components/tabs/SizePositionTab.tsx
+++ b/src/entrypoints/options/components/tabs/SizePositionTab.tsx
@@ -52,14 +52,14 @@ export default function SizePositionTab() {
           title={browser.i18n.getMessage("OptionsHeadingSize")}
         />
         {targetIsTab ? (
-          <Box marginY={1}>
+          <Box sx={{ my: 1 }}>
             <Alert severity="warning">
               {browser.i18n.getMessage("OptionsSettingsNotAvailableForTab")}
             </Alert>
           </Box>
         ) : (
           <>
-            <Box marginY={1}>
+            <Box sx={{ my: 1 }}>
               <SizeModeOptionControl />
             </Box>
             {sizeMode === "custom" && <CustomDimensionsForm />}
@@ -67,20 +67,20 @@ export default function SizePositionTab() {
         )}
       </Box>
       <Divider />
-      <Box marginTop={2}>
+      <Box sx={{ mt: 2 }}>
         <TabPanelHeader
           icon={<OpenWithIcon />}
           title={browser.i18n.getMessage("OptionsHeadingPosition")}
         />
         {targetIsTab ? (
-          <Box marginY={1}>
+          <Box sx={{ my: 1 }}>
             <Alert severity="warning">
               {browser.i18n.getMessage("OptionsSettingsNotAvailableForTab")}
             </Alert>
           </Box>
         ) : (
           <>
-            <Box marginY={1}>
+            <Box sx={{ my: 1 }}>
               <PositionModeOptionControl />
             </Box>
             {positionMode === "custom" && <CustomPositionForm />}


### PR DESCRIPTION
## Summary
- move removed MUI layout shorthand props into `sx`
- keep the options page layout behavior unchanged for the MUI 9 material update

## Validation
- `npm run compile`
- `npm run test`
- `npm run smoke:options`